### PR TITLE
Bumps up the fixmyjs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "atom": ">=0.135.0"
   },
   "dependencies": {
-    "fixmyjs": "^0.13.2",
+    "fixmyjs": "^1.0.x",
     "jshint": "^2.5.6"
   }
 }


### PR DESCRIPTION
1.0.0 is a cut of the 0.13.7 release. 0.13.7 added the option `multiVar` which turns one-var style into multiVar. The rest of the changes are documented in the [CHANGELOG](https://github.com/jshint/fixmyjs/blob/master/CHANGELOG.md)